### PR TITLE
modified alt texts under <Image> to be more descriptive

### DIFF
--- a/client/src/pages/assignments.tsx
+++ b/client/src/pages/assignments.tsx
@@ -68,7 +68,7 @@ export default function Assignments() {
                 <Image
                   priority={true}
                   src={assignment.musician.image}
-                  alt={`name of the selected musician is ${assignment.musician.first_name}`}
+                  alt={`assigned musician is ${assignment.musician.first_name}`}
                   width={200}
                   height={280}
                 />

--- a/client/src/pages/assignments.tsx
+++ b/client/src/pages/assignments.tsx
@@ -68,7 +68,7 @@ export default function Assignments() {
                 <Image
                   priority={true}
                   src={assignment.musician.image}
-                  alt={assignment.musician.first_name}
+                  alt={`name of the selected musician is ${assignment.musician.first_name}`}
                   width={200}
                   height={280}
                 />
@@ -79,7 +79,7 @@ export default function Assignments() {
               <div className={classNames(classes.image)}>
                 <Image
                   src={assignment.instrument.img}
-                  alt={assignment.instrument.name}
+                  alt={`assigned instrument is ${assignment.instrument.name}`}
                   width={200}
                 />
               </div>

--- a/client/src/pages/selection.tsx
+++ b/client/src/pages/selection.tsx
@@ -127,7 +127,7 @@ export default function Selection() {
                         <Image
                           priority={true}
                           src={musician.image}
-                          alt={musician.first_name}
+                          alt={`select ${musician.first_name}`}
                           width={200}
                           height={280}
                         />
@@ -157,7 +157,7 @@ export default function Selection() {
                   >
                     <Image
                       src={instrument.img}
-                      alt={instrument.name}
+                      alt={`select ${instrument.name}`}
                       width={200}
                     />
                   </div>
@@ -188,6 +188,7 @@ export default function Selection() {
           });
         }}
         disabled={!selectedEqual}
+        type={'button'}
       >
         Give me assignments!
       </button>


### PR DESCRIPTION
### Summary of Changes

Modified alt texts under <Image> (for both musicians and instruments) to be more descriptive.

modified files: 
- selections.tsx
- assignments.tsx

### Summary of Implementation Logic


### Issue Link

https://github.com/RubySpeeders/Drum-Roulette/issues/51

Original Issue: Issue 51

Dependent Issues:

Depends on Issues:



### Screen shots / Videos
It's getting a pretty good score! 
![Screenshot 2023-08-02 at 2 55 14 PM](https://github.com/RubySpeeders/Drum-Roulette/assets/102322200/fcb5bdda-73f7-4886-ae9a-18141d01193b)

...but I cannot find which image it is not finding "alt" attribute. As far as I can tell, all images have alt. 
![Screenshot 2023-08-02 at 3 06 30 PM](https://github.com/RubySpeeders/Drum-Roulette/assets/102322200/62ac5b33-1719-4f01-ae26-681a8981be33)

### Acceptance Criteria

I tested using chrome's built in tool "lighthouse" to test the current accessibility, however, I'm not sure if the new alt label is working correctly for users who use a tool such as VoiceOver. 

@charlottekies - if you know how to use VoiceOver or other tools similar, I'm curious if you could test it out to see if it's working as expected

---

### Checklist for PR Owner

- [ ] Standardized PR Title
- [ ] Included relevant videos and screen shots
- [ ] Included Summary of Changes
- [ ] Included Summary of Implementation Logic
- [ ] Acceptance Criteria are fufilled
