### PR TITLE
hotfix: adding height attritube in image tag on assignment page

### DIFF
--- a/client/src/pages/assignments.tsx
+++ b/client/src/pages/assignments.tsx
@@ -82,6 +82,7 @@ export default function Assignments() {
                   src={assignment.instrument.img}
                   alt={`assigned instrument is ${assignment.instrument.name}`}
                   width={200}
+                  height={200}
                 />
               </div>
               <Typography>{assignment.instrument.name}</Typography>


### PR DESCRIPTION
### Summary of Changes

<!---
One sentence or bullet list of changes that were included in this PR. Example:
- The changes in this PR grants ability to ... fix a bug that ... --->

---

This PR fixes the `Image` tag on the assignments page that is missing a `height` attribute.
### Summary of Implementation Logic

<!---
A short, bulleted list summarizing your implementation logic to help a reviewer understand at a high level of how your changes work. Example:

- Creates new "BandService.js" file in "services" directory where API calls are executed
- Imports BandService into SelectPlayers and calls bandService.getBands() method in useEffect() hook
- Sets state in ChoosePlayers.tsx with fetched data, handles error with user-friendly error message

Write your summary below this comment
--->

-adds `height={200}` on the Image tag in assignments.tsx for the instrument images.

---

### Issue Link

<!--- Capture links to your ticket, and any related tickets, here --->

Original Issue:

Dependent Issues:

Depends on Issues:

---

### Screen shots / Videos

<!--- Place relevant screen shots and videos here that would help reviewers conceptualize the changes --->

---

### Acceptance Criteria

<!--- Copy over the issue's Acceptance Criteria here. Check them off here to verify they have been fulfilled. --->

---

### Checklist for PR Owner

- [ ] Standardized PR Title
- [ ] Included relevant videos and screen shots
- [ ] Included Summary of Changes
- [ ] Included Summary of Implementation Logic
- [ ] Acceptance Criteria are fufilled
