### PR TITLE
DR 5 instrument image styling

### DIFF
--- a/client/src/components/ItemCard.tsx
+++ b/client/src/components/ItemCard.tsx
@@ -1,5 +1,6 @@
 // React/ Next.js Imports
 import Image from "next/image";
+import { useEffect, useState } from "react";
 
 // Library Imports
 import { Typography } from "@mui/material";
@@ -43,6 +44,15 @@ export const ItemCard = ({ item, onClick }: Props) => {
   const handleClick = () => {
     onClick(item);
   };
+  const [isInstrument, setInstrument] = useState(false);
+  // check if the image is an instrument
+  useEffect(() => {
+    if (item.image.includes("instruments")) {
+      setInstrument(true);
+    } else {
+      setInstrument(false);
+    }
+  }, []);
   const classes = useStyles();
   return (
     <div className={classNames(classes.card)}>
@@ -52,18 +62,33 @@ export const ItemCard = ({ item, onClick }: Props) => {
         })}
         onClick={handleClick}
       >
-        <Image
-          priority
-          src={item.image}
-          alt={`select ${
-            "first_name" in item
-              ? `${item.first_name} ${item.last_name}`
-              : item.name
-          }`}
-          width={200}
-          // if I set this to 200, instruments images are fixed but players image gets distorted
-          height={280}
-        />
+        {isInstrument ? (
+          // render players
+          <Image
+            priority
+            src={item.image}
+            alt={`select ${
+              "first_name" in item
+                ? `${item.first_name} ${item.last_name}`
+                : item.name
+            }`}
+            width={200}
+            height={200}
+          />
+        ) : (
+          // render instruments
+          <Image
+            priority
+            src={item.image}
+            alt={`select ${
+              "first_name" in item
+                ? `${item.first_name} ${item.last_name}`
+                : item.name
+            }`}
+            width={200}
+            height={280}
+          />
+        )}
       </div>
       <Typography style={{ marginTop: "5%" }}>
         {"first_name" in item

--- a/client/src/components/ItemCard.tsx
+++ b/client/src/components/ItemCard.tsx
@@ -35,6 +35,7 @@ const useStyles = makeStyles(() => ({
     borderRadius: "50%",
     display: "flex",
     justifyContent: "center",
+    background: "white",
   },
 }));
 
@@ -60,6 +61,7 @@ export const ItemCard = ({ item, onClick }: Props) => {
               : item.name
           }`}
           width={200}
+          // if I set this to 200, instruments images are fixed but players image gets distorted
           height={280}
         />
       </div>

--- a/client/src/components/ItemCard.tsx
+++ b/client/src/components/ItemCard.tsx
@@ -47,12 +47,8 @@ export const ItemCard = ({ item, onClick }: Props) => {
   const [isInstrument, setInstrument] = useState(false);
   // check if the image is an instrument
   useEffect(() => {
-    if (item.image.includes("instruments")) {
-      setInstrument(true);
-    } else {
-      setInstrument(false);
-    }
-  }, []);
+    setInstrument(item.image.includes("instruments"));
+  }, [item.image]);
   const classes = useStyles();
   return (
     <div className={classNames(classes.card)}>
@@ -80,11 +76,7 @@ export const ItemCard = ({ item, onClick }: Props) => {
           <Image
             priority
             src={item.image}
-            alt={`select ${
-              "first_name" in item
-                ? `${item.first_name} ${item.last_name}`
-                : item.name
-            }`}
+            alt={`select ${item}`}
             width={200}
             height={280}
           />

--- a/client/src/components/SelectionContainer.tsx
+++ b/client/src/components/SelectionContainer.tsx
@@ -30,7 +30,6 @@ const useStyles = makeStyles(() => ({
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    padding: "2.5rem 4rem",
   },
   card: {
     display: "flex",
@@ -114,63 +113,65 @@ export default function SelectionContainer({
   };
 
   return (
-    <Grid container>
-      <Grid item xs={12} md={6} className={classes.grid}>
-        <Box className={classNames(classes.container)}>
-          <h2>Select Musicians</h2>
-          <div className={classNames(classes.musicians)}>
-            {musicians.map((musician: Musician) => (
-              <ItemCard
-                key={musician.musician_id}
-                item={musician}
-                onClick={() => handleClickItem(musician)}
-              />
-            ))}
-          </div>
-        </Box>
-      </Grid>
-      <Grid item xs={12} md={6}>
-        <Box className={classNames(classes.container)}>
-          <h2>Select Instruments</h2>
-          <div className={classNames(classes.musicians)}>
-            {instruments.map((instrument: Instrument) => (
-              <ItemCard
-                key={instrument.id}
-                item={instrument}
-                onClick={() => handleClickItem(instrument)}
-              />
-            ))}
-          </div>
-        </Box>
-        {/* only render link tag if selection criteria are met */}
-        {!isSelected || !selectedEqual ? (
-          <CustomButton
-            variant="contained"
-            disabled={!isSelected || !selectedEqual}
-          >
-            Assign
-          </CustomButton>
-        ) : (
-          <Link
-            href={{
-              pathname: "/assignments",
-              query: {
-                assignments: JSON.stringify(assign(musicians, instruments)),
-              },
-            }}
-          >
+    <>
+      <Grid container>
+        <Grid item xs={12} md={6} className={classes.grid}>
+          <Box className={classNames(classes.container)}>
+            <h2>Select Musicians</h2>
+            <div className={classNames(classes.musicians)}>
+              {musicians.map((musician: Musician) => (
+                <ItemCard
+                  key={musician.musician_id}
+                  item={musician}
+                  onClick={() => handleClickItem(musician)}
+                />
+              ))}
+            </div>
+          </Box>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <Box className={classNames(classes.container)}>
+            <h2>Select Instruments</h2>
+            <div className={classNames(classes.musicians)}>
+              {instruments.map((instrument: Instrument) => (
+                <ItemCard
+                  key={instrument.id}
+                  item={instrument}
+                  onClick={() => handleClickItem(instrument)}
+                />
+              ))}
+            </div>
+          </Box>
+          {/* only render link tag if selection criteria are met */}
+          {!isSelected || !selectedEqual ? (
             <CustomButton
               variant="contained"
               disabled={!isSelected || !selectedEqual}
             >
               Assign
             </CustomButton>
+          ) : (
+            <Link
+              href={{
+                pathname: "/assignments",
+                query: {
+                  assignments: JSON.stringify(assign(musicians, instruments)),
+                },
+              }}
+            >
+              <CustomButton
+                variant="contained"
+                disabled={!isSelected || !selectedEqual}
+              >
+                Assign
+              </CustomButton>
+            </Link>
+          )}
+          <Link href="/">
+            <Typography>Return to homepage</Typography>
           </Link>
-        )}
-        <Link href="/">
-          <Typography>Return to homepage</Typography>
-        </Link>
+        </Grid>
       </Grid>
-    </Grid>
+    </>
   );
 }

--- a/client/src/components/SelectionContainer.tsx
+++ b/client/src/components/SelectionContainer.tsx
@@ -113,65 +113,63 @@ export default function SelectionContainer({
   };
 
   return (
-    <>
-      <Grid container>
-        <Grid item xs={12} md={6} className={classes.grid}>
-          <Box className={classNames(classes.container)}>
-            <h2>Select Musicians</h2>
-            <div className={classNames(classes.musicians)}>
-              {musicians.map((musician: Musician) => (
-                <ItemCard
-                  key={musician.musician_id}
-                  item={musician}
-                  onClick={() => handleClickItem(musician)}
-                />
-              ))}
-            </div>
-          </Box>
-        </Grid>
-        <Grid item xs={12} md={6}>
-          <Box className={classNames(classes.container)}>
-            <h2>Select Instruments</h2>
-            <div className={classNames(classes.musicians)}>
-              {instruments.map((instrument: Instrument) => (
-                <ItemCard
-                  key={instrument.id}
-                  item={instrument}
-                  onClick={() => handleClickItem(instrument)}
-                />
-              ))}
-            </div>
-          </Box>
-          {/* only render link tag if selection criteria are met */}
-          {!isSelected || !selectedEqual ? (
+    <Grid container>
+      <Grid item xs={12} md={6} className={classes.grid}>
+        <Box className={classNames(classes.container)}>
+          <h2>Select Musicians</h2>
+          <div className={classNames(classes.musicians)}>
+            {musicians.map((musician: Musician) => (
+              <ItemCard
+                key={musician.musician_id}
+                item={musician}
+                onClick={() => handleClickItem(musician)}
+              />
+            ))}
+          </div>
+        </Box>
+      </Grid>
+      <Grid item xs={12} md={6}>
+        <Box className={classNames(classes.container)}>
+          <h2>Select Instruments</h2>
+          <div className={classNames(classes.musicians)}>
+            {instruments.map((instrument: Instrument) => (
+              <ItemCard
+                key={instrument.id}
+                item={instrument}
+                onClick={() => handleClickItem(instrument)}
+              />
+            ))}
+          </div>
+        </Box>
+        {/* only render link tag if selection criteria are met */}
+        {!isSelected || !selectedEqual ? (
+          <CustomButton
+            variant="contained"
+            disabled={!isSelected || !selectedEqual}
+          >
+            Assign
+          </CustomButton>
+        ) : (
+          <Link
+            href={{
+              pathname: "/assignments",
+              query: {
+                assignments: JSON.stringify(assign(musicians, instruments)),
+              },
+            }}
+          >
             <CustomButton
               variant="contained"
               disabled={!isSelected || !selectedEqual}
             >
               Assign
             </CustomButton>
-          ) : (
-            <Link
-              href={{
-                pathname: "/assignments",
-                query: {
-                  assignments: JSON.stringify(assign(musicians, instruments)),
-                },
-              }}
-            >
-              <CustomButton
-                variant="contained"
-                disabled={!isSelected || !selectedEqual}
-              >
-                Assign
-              </CustomButton>
-            </Link>
-          )}
-          <Link href="/">
-            <Typography>Return to homepage</Typography>
           </Link>
-        </Grid>
+        )}
+        <Link href="/">
+          <Typography>Return to homepage</Typography>
+        </Link>
       </Grid>
-    </>
+    </Grid>
   );
 }


### PR DESCRIPTION
### Summary of Changes

- Added `background: "white"` prop to image prop to get rid of the cone shaped top 
- Added a conditional rendering so that instruments render with W:200 x H200 and players render W:200 x H280

---

### Summary of Implementation Logic

- Utilized `useState` hooks to check if `item.image` is an instrument image or a player. If it includes "instrument" in the file name, it sets the `isInstrument` to true, else it sets to false.
- The above check is wrapped in `useEffect` with an empty array dependency to avoid rendering more than once
- In the `return` block, using a ternary operator, it checks if `isInstrument` is true or false, and it renders `<Image >` component with different width & height property 

---

### Issue Link

<!--- Capture links to your ticket, and any related tickets, here --->

Original Issue: [Notion Ticket #5](https://www.notion.so/Instrument-Image-styling-b652f3bc5f0940ea91c1578bdd9da074?pvs=4)

Dependent Issues:

Depends on Issues:

---

### Screen shots / Videos
<img width="726" alt="DR-5-Instrument-Image-Fixed-img" src="https://github.com/RubySpeeders/Drum-Roulette/assets/102322200/e13a25a1-5400-4818-b421-cd9d22c2cb2e">

---

### Acceptance Criteria

Fix instruments to be circles instead of the football shape they currently are.

---

### Checklist for PR Owner

- [X] Standardized PR Title
- [X] Included relevant videos and screen shots
- [X] Included Summary of Changes
- [X] Included Summary of Implementation Logic
- [X] Acceptance Criteria are fufilled
